### PR TITLE
[DOC] Add warning about using mapca

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # mapca
 A Python implementation of the moving average principal components analysis methods from GIFT
+
+## Usage
+
+**Please do not use this library.** The `mapca` library does not yet have a license, since it was developed from MATLAB code in another package without a license. We have contacted the MATLAB library's authors about licensing and will take the appropriate steps when we hear back from them. We have only made `mapca` public to make it easier to run CI.


### PR DESCRIPTION
I've added a warning to the README so that we can make this repo public without worrying about the missing license. That will make it easier to set up CodeCov and other things.