### PR TITLE
[FIX] Tests import module from wrong location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
           name: Running unit tests
           command: |
             source activate mapca_py35
+            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage
             mv /tmp/src/mapca/.coverage /tmp/src/coverage/.coverage.py35
@@ -82,6 +83,7 @@ jobs:
           name: Running unit tests
           command: |
             source activate mapca_py36
+            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage
             mv /tmp/src/mapca/.coverage /tmp/src/coverage/.coverage.py36
@@ -106,6 +108,7 @@ jobs:
           name: Running unit tests
           command: |
             apt-get install -y make
+            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             source activate mapca_py37  # depends on makeenv_37
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
           name: Running unit tests
           command: |
             source activate mapca_py35
-            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage
             mv /tmp/src/mapca/.coverage /tmp/src/coverage/.coverage.py35
@@ -83,7 +82,6 @@ jobs:
           name: Running unit tests
           command: |
             source activate mapca_py36
-            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage
             mv /tmp/src/mapca/.coverage /tmp/src/coverage/.coverage.py36
@@ -108,7 +106,6 @@ jobs:
           name: Running unit tests
           command: |
             apt-get install -y make
-            export PYTHONPATH=/tmp/src/mapca:${PYTHONPATH}
             source activate mapca_py37  # depends on makeenv_37
             py.test --cov-append --cov-report term-missing --cov=mapca mapca/
             mkdir /tmp/src/coverage

--- a/mapca/tests/__init__.py
+++ b/mapca/tests/__init__.py
@@ -1,0 +1,2 @@
+# emacs: -*- mode: python-mode; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 et:


### PR DESCRIPTION
Closes #12.

It looks like the tests are importing the module installed at  `/opt/conda/envs/mapca_py37/lib/python3.7/site-packages/mapca` instead of the one at `/tmp/src/mapca`. As a result, codecov thinks the module has no coverage.

One fix is to prioritize the `src` folder by modifying the `PYTHONPATH` variable (first commit).
The other way is to add an `__init__.py` file to the tests folder 🤷. I copied the file from `tedana`. (second commit --- also undoes the first commit).