### PR TITLE
Skip parzen_win steps if sm_window is false

### DIFF
--- a/mapca/tests/test_utils.py
+++ b/mapca/tests/test_utils.py
@@ -58,6 +58,7 @@ def test_ent_rate_sp():
     Check that ent_rate_sp runs correctly, i.e. returns a float
     """
     test_data = np.random.rand(200, 10, 10)
+    ent_rate = ent_rate_sp(test_data, 0)
     ent_rate = ent_rate_sp(test_data, 1)
     assert isinstance(ent_rate, float)
     assert ent_rate.ndim == 0

--- a/mapca/utils.py
+++ b/mapca/utils.py
@@ -159,19 +159,6 @@ def ent_rate_sp(data, sm_window):
         raise ValueError("Divide by zero encountered.")
     data = data / data_std
 
-    if sm_window:
-        M = [int(i) for i in np.ceil(np.array(dims) / 10)]
-
-        # Get Parzen window for each spatial direction
-        parzen_w_3 = np.zeros((2 * dims[2] - 1,))
-        parzen_w_3[(dims[2] - M[2] - 1) : (dims[2] + M[2])] = _parzen_win(2 * M[2] + 1)
-
-        parzen_w_2 = np.zeros((2 * dims[1] - 1,))
-        parzen_w_2[(dims[1] - M[1] - 1) : (dims[1] + M[1])] = _parzen_win(2 * M[1] + 1)
-
-        parzen_w_1 = np.zeros((2 * dims[0] - 1,))
-        parzen_w_1[(dims[0] - M[0] - 1) : (dims[0] + M[0])] = _parzen_win(2 * M[0] + 1)
-
     # Apply windows to 3D
     # TODO: replace correlate2d with 3d if possible
     data_corr = np.zeros((2 * dims[0] - 1, 2 * dims[1] - 1, 2 * dims[2] - 1))
@@ -199,6 +186,18 @@ def ent_rate_sp(data, sm_window):
     data_corr /= vcu
 
     if sm_window:
+        M = [int(i) for i in np.ceil(np.array(dims) / 10)]
+
+        # Get Parzen window for each spatial direction
+        parzen_w_3 = np.zeros((2 * dims[2] - 1,))
+        parzen_w_3[(dims[2] - M[2] - 1) : (dims[2] + M[2])] = _parzen_win(2 * M[2] + 1)
+
+        parzen_w_2 = np.zeros((2 * dims[1] - 1,))
+        parzen_w_2[(dims[1] - M[1] - 1) : (dims[1] + M[1])] = _parzen_win(2 * M[1] + 1)
+
+        parzen_w_1 = np.zeros((2 * dims[0] - 1,))
+        parzen_w_1[(dims[0] - M[0] - 1) : (dims[0] + M[0])] = _parzen_win(2 * M[0] + 1)
+
         # Scale Parzen windows
         parzen_window_2D = np.dot(parzen_w_1[np.newaxis, :].T, parzen_w_2[np.newaxis, :])
         parzen_window_3D = np.zeros((2 * dims[0] - 1, 2 * dims[1] - 1, 2 * dims[2] - 1))

--- a/mapca/utils.py
+++ b/mapca/utils.py
@@ -198,19 +198,20 @@ def ent_rate_sp(data, sm_window):
 
     data_corr /= vcu
 
-    # Scale Parzen windows
-    parzen_window_2D = np.dot(parzen_w_1[np.newaxis, :].T, parzen_w_2[np.newaxis, :])
-    parzen_window_3D = np.zeros((2 * dims[0] - 1, 2 * dims[1] - 1, 2 * dims[2] - 1))
-    for m3 in range(dims[2] - 1):
-        parzen_window_3D[:, :, (dims[2] - 1) - m3] = np.dot(
-            parzen_window_2D, parzen_w_3[dims[2] - 1 - m3]
-        )
-        parzen_window_3D[:, :, (dims[2] - 1) + m3] = np.dot(
-            parzen_window_2D, parzen_w_3[dims[2] - 1 + m3]
-        )
+    if sm_window:
+        # Scale Parzen windows
+        parzen_window_2D = np.dot(parzen_w_1[np.newaxis, :].T, parzen_w_2[np.newaxis, :])
+        parzen_window_3D = np.zeros((2 * dims[0] - 1, 2 * dims[1] - 1, 2 * dims[2] - 1))
+        for m3 in range(dims[2] - 1):
+            parzen_window_3D[:, :, (dims[2] - 1) - m3] = np.dot(
+                parzen_window_2D, parzen_w_3[dims[2] - 1 - m3]
+            )
+            parzen_window_3D[:, :, (dims[2] - 1) + m3] = np.dot(
+                parzen_window_2D, parzen_w_3[dims[2] - 1 + m3]
+            )
+        # Apply 3D Parzen Window
+        data_corr *= parzen_window_3D
 
-    # Apply 3D Parzen Window
-    data_corr *= parzen_window_3D
     data_fft = abs(fftshift(fftn(data_corr)))
     data_fft[data_fft < 1e-4] = 1e-4
 


### PR DESCRIPTION
`utils.ent_rate_sp` fails if the `sm_window` argument is false. This PR fixes that.

Alternative fix: Remove the `sm_window` argument and always use the parzen windows. Currently, `sm_window` is set to true and I don't think users have a way of changing this setting.
https://github.com/ME-ICA/mapca/blob/0d01a2b3d87a12e8f6778fbd549f8e83c05b58c1/mapca/utils.py#L253