### PR TITLE
Add citation and link to GIFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A Python implementation of the moving average principal components analysis meth
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/ME-ICA/mapca.svg)](http://isitmaintained.com/project/ME-ICA/mapca "Percentage of issues still open")
 [![Join the chat at https://gitter.im/ME-ICA/mapca](https://badges.gitter.im/ME-ICA/mapca.svg)](https://gitter.im/ME-ICA/mapca?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-## Usage
+## About
 
-**Please do not use this library.** The `mapca` library does not yet have a license, since it was developed from MATLAB code in another package without a license. We have contacted the MATLAB library's authors about licensing and will take the appropriate steps when we hear back from them. We have only made `mapca` public to make it easier to run CI.
+`mapca` is a Python package that performs dimensionality reduction with principal component analysis (PCA) on functional magnetic resonance imaging (fMRI) data. It is a translation to Python of the dimensionality reduction technique used in the MATLAB-based [GIFT package](https://trendscenter.org/software/gift/) and introduced by Li et al. 2007[^1].
+
+[^1]: Li, Y. O., Adali, T., & Calhoun, V. D. (2007). Estimating the number of independent components for functional magnetic resonance imaging data. Human Brain Mapping, 28(11), 1251–1266. https://doi.org/10.1002/hbm.20359

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -86,6 +86,11 @@ class MovingAveragePCA:
         self.normalize = normalize
 
     def _fit(self, X, shape_3d, mask_vec):
+        LGR.info("Performing dimensionality reduction based on GIFT "
+                 "(https://trendscenter.org/software/gift/) and Li, Y. O., Adali, T., "
+                 "& Calhoun, V. D. (2007). Estimating the number of independent components "
+                 "for functional magnetic resonance imaging data. Human Brain Mapping, 28(11), "
+                 "1251–1266. https://doi.org/10.1002/hbm.20359")
         n_x, n_y, n_z = shape_3d
         n_samples, n_timepoints = X.shape
 

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -74,9 +74,9 @@ class MovingAveragePCA:
 
     References
     ----------
-    Li, Y. O., Adali, T., & Calhoun, V. D. (2007). Estimating the number of
-    independent components for functional magnetic resonance imaging data.
-    Human Brain Mapping, 28(11), 1251–1266. https://doi.org/10.1002/hbm.20359
+    * Li, Y. O., Adali, T., & Calhoun, V. D. (2007). Estimating the number of
+      independent components for functional magnetic resonance imaging data.
+      Human Brain Mapping, 28(11), 1251–1266. https://doi.org/10.1002/hbm.20359
 
     Translated from the MATLAB code available in GIFT. https://trendscenter.org/software/gift/
     """

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -71,6 +71,14 @@ class MovingAveragePCA:
 
         Equal to the average of (min(n_features, n_samples) - n_components) smallest
         eigenvalues of the covariance matrix of X.
+
+    References
+    ----------
+    Li, Y. O., Adali, T., & Calhoun, V. D. (2007). Estimating the number of
+    independent components for functional magnetic resonance imaging data.
+    Human Brain Mapping, 28(11), 1251–1266. https://doi.org/10.1002/hbm.20359
+
+    Translated from the MATLAB code available in GIFT. https://trendscenter.org/software/gift/
     """
 
     def __init__(self, criterion="mdl", normalize=True):


### PR DESCRIPTION
Closes #27 

This PR adds the necessary citations and links to GIFT to make the package publicly available:

- [x]  Cite GIFT and maPCA in the README.
- [x]  Cite GIFT and maPCA in the code.
- [x]  Make the logger return the citation.