### PR TITLE
[REF] Use nilearn and images instead of arrays

### DIFF
--- a/mapca/utils.py
+++ b/mapca/utils.py
@@ -3,6 +3,7 @@ PCA based on Moving Average (stationary Gaussian) process
 """
 import logging
 
+import nibabel as nib
 import numpy as np
 from scipy.fftpack import fftn, fftshift
 from scipy.linalg import svd
@@ -179,7 +180,7 @@ def _est_indp_sp(data):
     return n_iters, ent_rate
 
 
-def _subsampling(data, sub_depth):
+def _subsampling(img, sub_depth):
     """
     Subsampling the data evenly with space 'sub_depth'.
 
@@ -195,10 +196,25 @@ def _subsampling(data, sub_depth):
     out : ndarray
         Subsampled data
     """
+    if not isinstance(img, np.ndarray):
+        data = img.get_fdata()
 
+        # Prepare image
+        target_affine = img.affine.copy()
+        diag = np.diag(target_affine).copy()
+        diag[:3] *= sub_depth
+        np.fill_diagonal(target_affine, diag)
+    else:
+        data = img.copy()
     slices = [slice(None, None, sub_depth)] * data.ndim
-    out = data[tuple(slices)]
-    return out
+    subsampled_data = data[tuple(slices)]
+
+    if not isinstance(img, np.ndarray):
+        subsampled_img = nib.Nifti1Image(subsampled_data, target_affine, img.header)
+    else:
+        subsampled_img = subsampled_data
+
+    return subsampled_img
 
 
 def _kurtn(data):


### PR DESCRIPTION
Closes #31 and closes #34.

Changes proposed:

- Allow `utils._subsampling()` to accept either an array or an image. Ultimately, we may want to limit this to just images, but I haven't done that yet.
- Use nilearn's masking functions instead of internal implementations.