### PR TITLE
[FIX] Drop setuptools version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # mapca
 A Python implementation of the moving average principal components analysis methods from GIFT
 
+[![Latest Version](https://img.shields.io/pypi/v/mapca.svg)](https://pypi.python.org/pypi/mapca/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mapca.svg)](https://pypi.python.org/pypi/mapca/)
+[![License](https://img.shields.io/badge/license-GPL--2.0-blue.svg)](https://opensource.org/licenses/GPL-2.0)
 [![CircleCI](https://circleci.com/gh/ME-ICA/mapca.svg?style=shield)](https://circleci.com/gh/ME-ICA/mapca)
 [![Codecov](https://codecov.io/gh/ME-ICA/mapca/branch/main/graph/badge.svg?token=GEKDT6R0B7)](https://codecov.io/gh/ME-ICA/mapca)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/ME-ICA/mapca.svg)](http://isitmaintained.com/project/ME-ICA/mapca "Average time to resolve an issue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==40.8", "wheel"]
+requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ def main():
         version=vars["VERSION"],
         description=vars["DESCRIPTION"],
         long_description=vars["LONGDESC"],
+        long_description_content_type="text/markdown",
         author=vars["AUTHOR"],
         author_email=vars["EMAIL"],
         maintainer=vars["MAINTAINER"],


### PR DESCRIPTION
The pinned version was causing https://github.com/ME-ICA/mapca/issues/6#issuecomment-799675793. After dropping the version requirement, I was able to upload to TestPyPi without issue.