### PR TITLE
Made maPCA class accessible for other libraries

### DIFF
--- a/mapca/__init__.py
+++ b/mapca/__init__.py
@@ -3,9 +3,9 @@ mapca: A Python implementation of the moving average principal components analys
 GIFT.
 """
 
-from .due import due, Doi
 from ._version import get_versions
-from .mapca import ma_pca
+from .due import Doi, due
+from .mapca import MovingAveragePCA, ma_pca
 
 __version__ = get_versions()["version"]
 
@@ -16,6 +16,7 @@ warnings.filterwarnings("ignore", r"cmp not installed")
 
 __all__ = [
     "ma_pca",
+    "MovingAveragePCA",
     "__version__",
 ]
 


### PR DESCRIPTION
Closes none.

I'm working on a PR for tedana to make the optimal number of components of all 3 options visible to users. In order to make that possible, it is necessary to make the `MovingAveragePCA` class callable in `__init__.py`.