### PR TITLE
Option to set IID subsample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ target/
 profile_default/
 ipython_config.py
 
+# VSCode
+.vscode/
+
 # pyenv
 .python-version
 

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -209,7 +209,18 @@ class MovingAveragePCA:
             dim_n = x_single.ndim
 
         sub_iid_sp_median = int(np.round(np.median(sub_iid_sp)))
-        LGR.info(f"Esimated subsampling depth for effective i.i.i samples: {sub_iid_sp_median}")
+        # Will log the mean value to check if the differences in median within a dataset
+        # represent very small changes in the mean. It seems like this is the closest
+        # to a non-discrete value to store to compare across runs.
+        sub_iid_sp_mean = np.round(np.mean(sub_iid_sp),3)
+
+
+        if np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)) < sub_iid_sp_median:
+            LGR.info(f"Subsampling IID depth estimate too high. Subsampling depth will "
+                     "be defined by number of datapoints rather than IID estimates.")
+            sub_iid_sp_median = int(np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)))
+
+        LGR.info(f"Estimated subsampling depth for effective i.i.d samples: {sub_iid_sp_median}")
 
         # Always save the calculated IID subsample value, but, if there is a user provide value, assign that to sub_iid_sp_median
         #   and use that instead
@@ -221,10 +232,6 @@ class MovingAveragePCA:
                 raise ValueError(f"IIDsubsample must be an integer between 1 and the number of samples. It is {IIDsubsample}")
 
 
-
-
-        if np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)) < sub_iid_sp_median:
-            sub_iid_sp_median = int(np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)))
         N = np.round(n_samples / np.power(sub_iid_sp_median, dim_n))
 
         if sub_iid_sp_median != 1:
@@ -360,6 +367,8 @@ class MovingAveragePCA:
         }
         self.subsampling_ = {
             "calculated_IID_subsample_depth": calculated_sub_iid_sp_median,
+            "calculated_IID_subsample_mean": sub_iid_sp_mean,
+            "IID_subsample_input": sub_iid_sp,
             "used_IID_subsample_depth": sub_iid_sp_median,
             "effective_num_IID_samples": N,
             "total_num_samples": n_samples,

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -228,7 +228,7 @@ class MovingAveragePCA:
             if ((isinstance(subsample_depth, int)
                  or (isinstance(subsample_depth, float)
                  and subsample_depth == int(subsample_depth)))
-                 and (1 <= subsample_depth) and ((n_samples / (subsample_depth ** 3)) >= 100)):
+                and (1 <= subsample_depth) and ((n_samples / (subsample_depth ** 3)) >= 100)):
                 sub_iid_sp_median = subsample_depth
             else:
                 # The logic of the upper bound is subsample_depth^3 is the fraction of samples

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -212,27 +212,31 @@ class MovingAveragePCA:
         # Will log the mean value to check if the differences in median within a dataset
         # represent very small changes in the mean. It seems like this is the closest
         # to a non-discrete value to store to compare across runs.
-        sub_iid_sp_mean = np.round(np.mean(sub_iid_sp),3)
-
+        sub_iid_sp_mean = np.round(np.mean(sub_iid_sp), 3)
 
         if np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)) < sub_iid_sp_median:
-            LGR.info(f"Subsampling IID depth estimate too high. Subsampling depth will "
+            LGR.info("Subsampling IID depth estimate too high. Subsampling depth will "
                      "be defined by number of datapoints rather than IID estimates.")
             sub_iid_sp_median = int(np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)))
 
-        LGR.info(f"Estimated subsampling depth for effective i.i.d samples: {sub_iid_sp_median}")
+        LGR.info("Estimated subsampling depth for effective i.i.d samples: %d" % sub_iid_sp_median)
 
-        # Always save the calculated IID subsample value, but, if there is a user provide value, assign that to sub_iid_sp_median
-        #   and use that instead
+        # Always save the calculated IID subsample value, but, if there is a user provide value, 
+        # assign that to sub_iid_sp_median and use that instead
         calculated_sub_iid_sp_median = sub_iid_sp_median
         if subsample_depth:
-            if (isinstance(subsample_depth, int) or (isinstance(subsample_depth, float) and subsample_depth == int(subsample_depth))) and (1 <= subsample_depth) and ((n_samples/(subsample_depth ** 3)) >= 100):        
+            if ((isinstance(subsample_depth, int) or (isinstance(subsample_depth, float) 
+                                                     and subsample_depth == int(subsample_depth)))
+                and (1 <= subsample_depth) and ((n_samples/(subsample_depth ** 3)) >= 100)):        
                 sub_iid_sp_median = subsample_depth
             else:
-                # The logic of the upper bound is subsample_depth^3 is the fraction of samples that removed and it would be good to have at least 100 sampling remaining to have a useful analysis
-                # Given a masked volume is going to result in fewer samples remaining in 3D space, this is likely a very liberal upper bound, but
+                # The logic of the upper bound is subsample_depth^3 is the fraction of samples
+                # that removed and it would be good to have at least 100 sampling remaining to
+                # have a useful analysis. Given a masked volume is going to result in fewer
+                # samples remaining in 3D space, this is likely a very liberal upper bound, but
                 # probably good to at least include an upper bound.
-                raise ValueError(f"subsample_depth must be an integer > 1 and will retain at least 100 samples after subsampling. It is {subsample_depth}")
+                raise ValueError("subsample_depth must be an integer > 1 and will retain >100 "
+                                 "samples after subsampling. It is %d" % subsample_depth)
 
 
         N = np.round(n_samples / np.power(sub_iid_sp_median, dim_n))
@@ -408,13 +412,12 @@ class MovingAveragePCA:
             Mask to apply on ``img``.
         subsample_depth : int, optional
             Dimensionality reduction is calculated on a subset of voxels defined by
-            this depth. 2 would mean using every other voxel in 3D space and 3 would 
-            mean every 3rd voxel. Default=None (estimated depth to make remaining 
+            this depth. 2 would mean using every other voxel in 3D space and 3 would
+            mean every 3rd voxel. Default=None (estimated depth to make remaining
             voxels independent and identically distributed (IID)
             The subsampling value so that the voxels are assumed to be
             independent and identically distributed (IID).
             Default=None (use estimated value)
-
 
         Returns
         -------
@@ -435,8 +438,8 @@ class MovingAveragePCA:
             Mask to apply on ``img``.
         subsample_depth : int, optional
             Dimensionality reduction is calculated on a subset of voxels defined by
-            this depth. 2 would mean using every other voxel in 3D space and 3 would 
-            mean every 3rd voxel. Default=None (estimated depth to make remaining 
+            this depth. 2 would mean using every other voxel in 3D space and 3 would
+            mean every 3rd voxel. Default=None (estimated depth to make remaining
             voxels independent and identically distributed (IID)
 
         Returns
@@ -551,8 +554,8 @@ def ma_pca(img, mask, criterion="mdl", normalize=False, subsample_depth=None):
         Whether to normalize (zero mean and unit standard deviation) or not. Default is False.
     subsample_depth : int, optional
         Dimensionality reduction is calculated on a subset of voxels defined by
-        this depth. 2 would mean using every other voxel in 3D space and 3 would 
-        mean every 3rd voxel. Default=None (estimated depth to make remaining 
+        this depth. 2 would mean using every other voxel in 3D space and 3 would
+        mean every 3rd voxel. Default=None (estimated depth to make remaining
         voxels independent and identically distributed (IID)
 
     Returns

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -215,8 +215,10 @@ class MovingAveragePCA:
         sub_iid_sp_mean = np.round(np.mean(sub_iid_sp), 3)
 
         if np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)) < sub_iid_sp_median:
-            LGR.info("Subsampling IID depth estimate too high. Subsampling depth will "
-                     "be defined by number of datapoints rather than IID estimates.")
+            LGR.info(
+                "Subsampling IID depth estimate too high. Subsampling depth will "
+                "be defined by number of datapoints rather than IID estimates."
+            )
             sub_iid_sp_median = int(np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)))
 
         LGR.info("Estimated subsampling depth for effective i.i.d samples: %d" % sub_iid_sp_median)
@@ -225,19 +227,29 @@ class MovingAveragePCA:
         # assign that to sub_iid_sp_median and use that instead
         calculated_sub_iid_sp_median = sub_iid_sp_median
         if subsample_depth:
-            if ((isinstance(subsample_depth, int)
-                 or (isinstance(subsample_depth, float)
-                 and subsample_depth == int(subsample_depth)))
-                and (1 <= subsample_depth) and ((n_samples / (subsample_depth ** 3)) >= 100)):
+            if (
+                (
+                    isinstance(subsample_depth, int)
+                    or (
+                        isinstance(subsample_depth, float)
+                        and subsample_depth == int(subsample_depth)
+                    )
+                )
+                and (1 <= subsample_depth)
+                and ((n_samples / (subsample_depth**3)) >= 100)
+            ):
                 sub_iid_sp_median = subsample_depth
+
             else:
                 # The logic of the upper bound is subsample_depth^3 is the fraction of samples
                 # that removed and it would be good to have at least 100 sampling remaining to
                 # have a useful analysis. Given a masked volume is going to result in fewer
                 # samples remaining in 3D space, this is likely a very liberal upper bound, but
                 # probably good to at least include an upper bound.
-                raise ValueError("subsample_depth must be an integer > 1 and will retain >100 "
-                                 "samples after subsampling. It is %d" % subsample_depth)
+                raise ValueError(
+                    "subsample_depth must be an integer > 1 and will retain >100 "
+                    "samples after subsampling. It is %d" % subsample_depth
+                )
 
         N = np.round(n_samples / np.power(sub_iid_sp_median, dim_n))
 

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -221,13 +221,14 @@ class MovingAveragePCA:
 
         LGR.info("Estimated subsampling depth for effective i.i.d samples: %d" % sub_iid_sp_median)
 
-        # Always save the calculated IID subsample value, but, if there is a user provide value, 
+        # Always save the calculated IID subsample value, but, if there is a user provide value,
         # assign that to sub_iid_sp_median and use that instead
         calculated_sub_iid_sp_median = sub_iid_sp_median
         if subsample_depth:
-            if ((isinstance(subsample_depth, int) or (isinstance(subsample_depth, float) 
-                                                     and subsample_depth == int(subsample_depth)))
-                and (1 <= subsample_depth) and ((n_samples/(subsample_depth ** 3)) >= 100)):        
+            if ((isinstance(subsample_depth, int)
+                 or (isinstance(subsample_depth, float)
+                 and subsample_depth == int(subsample_depth)))
+                 and (1 <= subsample_depth) and ((n_samples / (subsample_depth ** 3)) >= 100)):
                 sub_iid_sp_median = subsample_depth
             else:
                 # The logic of the upper bound is subsample_depth^3 is the fraction of samples
@@ -237,7 +238,6 @@ class MovingAveragePCA:
                 # probably good to at least include an upper bound.
                 raise ValueError("subsample_depth must be an integer > 1 and will retain >100 "
                                  "samples after subsampling. It is %d" % subsample_depth)
-
 
         N = np.round(n_samples / np.power(sub_iid_sp_median, dim_n))
 

--- a/mapca/tests/conftest.py
+++ b/mapca/tests/conftest.py
@@ -53,7 +53,7 @@ def test_mask(testpath):
 @pytest.fixture
 def test_ts(testpath):
     return fetch_file('gz2hb', testpath,
-                      'compt_ts.npy')
+                      'comp_ts.npy')
 
 
 @pytest.fixture

--- a/mapca/tests/test_mapca.py
+++ b/mapca/tests/test_mapca.py
@@ -95,3 +95,9 @@ def test_MovingAveragePCA():
 
     test_data_est = pca2.inverse_transform(u2, test_mask_img)
     assert test_data_est.shape == test_img.shape
+
+    # Testing setting inputting a pre-defined subsampling depth
+    pca3 = MovingAveragePCA(criterion="mdl", normalize=False)
+    pca3.fit(test_img, test_mask_img, subsample_depth=2)
+    assert pca3.subsampling_['calculated_IID_subsample_depth'] == 1
+    assert pca3.subsampling_['used_IID_subsample_depth'] == 2


### PR DESCRIPTION
As discussed at the May 2023 tedana developers call, we decided to add an option to let a user set the IID subsampling value `sub_iid_sp_median` I think this PR has it working, but I want to make sure everything is correct and properly documented before saying it's ready to merge.

As part of this PR, we'll always estimate the IID subsample and both the estimated IID subsample and the one used (different if user provided) will be logged.