### PR TITLE
logging IID subsampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ target/
 profile_default/
 ipython_config.py
 
+# VSCode
+.vscode/
+
 # pyenv
 .python-version
 

--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -210,8 +210,8 @@ class MovingAveragePCA:
 
         sub_iid_sp_median = int(np.round(np.median(sub_iid_sp)))
 
-        # Calculating and logging the mean value to check if the differences in median 
-        # within a dataset represent very small changes in the mean. It seems like this 
+        # Calculating and logging the mean value to check if the differences in median
+        # within a dataset represent very small changes in the mean. It seems like this
         # is the closest to a non-discrete value to store to compare across runs.
         sub_iid_sp_mean = np.round(np.mean(sub_iid_sp), 3)
 
@@ -221,7 +221,7 @@ class MovingAveragePCA:
                 "be defined by number of datapoints rather than IID estimates."
             )
             sub_iid_sp_median = int(np.floor(np.power(n_samples / n_timepoints, 1 / dim_n)))
-        
+
         LGR.info("Estimated subsampling depth for effective i.i.d samples: %d" % sub_iid_sp_median)
 
         N = np.round(n_samples / np.power(sub_iid_sp_median, dim_n))


### PR DESCRIPTION
I'm still mixed on what to do with #56, but I'm realizing that PR has two parts. It both lets users set the subsampling values and it logs the estimated value. I not sure if it's worth letting users set the value, but we really want this information logged and I don't want to hold up that part. Here's a PR that just logs the info. If it looks good, I'd like to see this merged soonish. I'll open a paired PR for tedana so that the values will be stored with the tedana outputs.