### PR TITLE
deal with nilearn changes

### DIFF
--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -22,11 +22,17 @@ import logging
 
 import nibabel as nib
 import numpy as np
+from nilearn import __version__ as nilearn_version
 from nilearn import masking
-from nilearn._utils.niimg_conversions import check_niimg_3d, check_niimg_4d
+from packaging.version import Version
 from scipy.stats import kurtosis
 from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
+
+if Version(nilearn_version) >= Version("0.13.0"):
+    from nilearn.image import check_niimg_3d, check_niimg_4d
+else:
+    from nilearn._utils.niimg_conversions import check_niimg_3d, check_niimg_4d
 
 from mapca import utils
 

--- a/mapca/tests/test_integration.py
+++ b/mapca/tests/test_integration.py
@@ -25,7 +25,7 @@ def test_integration(test_img, test_mask, test_ts, test_varex, test_varex_norm, 
     v_norm = np.load(test_varex_norm)
     comp_ts = np.load(test_ts)
 
-    assert np.allclose(voxel_comp_weights, u)
+    assert np.allclose(voxel_comp_weights, u) or np.allclose(voxel_comp_weights, -1 * u)
     assert np.allclose(varex, s)
     assert np.allclose(v_norm, varex_norm)
     assert np.allclose(comp_ts, v)

--- a/mapca/tests/test_integration.py
+++ b/mapca/tests/test_integration.py
@@ -25,10 +25,13 @@ def test_integration(test_img, test_mask, test_ts, test_varex, test_varex_norm, 
     v_norm = np.load(test_varex_norm)
     comp_ts = np.load(test_ts)
 
-    assert np.allclose(voxel_comp_weights, u) or np.allclose(voxel_comp_weights, -1 * u)
+    # should be the same, but with sign-flips of rows accounted for
+    assert np.allclose(
+        voxel_comp_weights, np.sign(voxel_comp_weights[0, :]) * np.sign(u[0, :]) * u
+    )
     assert np.allclose(varex, s)
     assert np.allclose(v_norm, varex_norm)
-    assert np.allclose(comp_ts, v)
+    assert np.allclose(comp_ts, np.sign(comp_ts[0, :]) * np.sign(v[0, :]) * v)
 
     # Remove files
     shutil.rmtree(test_path)


### PR DESCRIPTION
niilearn moved some functions from `nilearn._utils.niimg_conversions` to `nilearn.image`. We added clause to deal with this in tedana, but this just caused an issue in mapca so I added it here as well.

An integration test is now failing. I briefly looked at the failure and it looks like values flipped postive/negative, but I haven't dug more yet.