### PR TITLE
replace np.row_stack with np.vstack

### DIFF
--- a/mapca/mapca.py
+++ b/mapca/mapca.py
@@ -317,7 +317,7 @@ class MovingAveragePCA:
             kic[k_idx] = (-2 * mlh) + (3 * df)
             mdl[k_idx] = -mlh + (0.5 * df * np.log(n))
 
-        itc = np.row_stack([aic, kic, mdl])
+        itc = np.vstack([aic, kic, mdl])
 
         dlap = np.diff(itc, axis=1)
 


### PR DESCRIPTION
One of the tedana integration tests was failing. I traced it back to mapca using `np.row_stack` which was deprecated in numpy 2.0 in favor of `np.vstack`. https://github.com/numpy/numpy/pull/24445

Not sure sure why this wasn't causing any issues before now. I think the following chance should fix this issue.

If merged, we should also release a new version of mapca and pin tedana to that newer version.